### PR TITLE
feat: support partition by and order by

### DIFF
--- a/starrocks/dialect.py
+++ b/starrocks/dialect.py
@@ -18,7 +18,6 @@ from sqlalchemy import exc, schema as sa_schema
 from sqlalchemy.dialects.mysql.pymysql import MySQLDialect_pymysql
 from sqlalchemy.dialects.mysql.base import MySQLDDLCompiler, MySQLTypeCompiler, MySQLCompiler, MySQLIdentifierPreparer
 from sqlalchemy.sql import sqltypes
-from sqlalchemy.util import topological
 from sqlalchemy import util
 from sqlalchemy import log
 from sqlalchemy.engine import reflection
@@ -229,15 +228,17 @@ class StarRocksDDLCompiler(MySQLDDLCompiler):
         if 'DISTRIBUTED_BY' in opts:
             table_opts.append(f'DISTRIBUTED BY HASH({opts["DISTRIBUTED_BY"]})')
 
+        if 'PARTITION_BY' in opts:
+            table_opts.append(f'PARTITION BY {opts["PARTITION_BY"]}')
+
+        if 'ORDER_BY' in opts:
+            table_opts.append(f'ORDER BY {opts["ORDER_BY"]}')
+
         if "COMMENT" in opts:
             comment = self.sql_compiler.render_literal_value(
                 opts["COMMENT"], sqltypes.String()
             )
             table_opts.append(f"COMMENT {comment}")
-
-        # ToDo - Partition
-        # ToDo - Distribution
-        # ToDo - Order by
 
         if "PROPERTIES" in opts:
             props = ",\n".join([f'\t"{k}"="{v}"' for k, v in opts["PROPERTIES"]])

--- a/starrocks/dialect.py
+++ b/starrocks/dialect.py
@@ -225,14 +225,14 @@ class StarRocksDDLCompiler(MySQLDDLCompiler):
         if 'PRIMARY_KEY' in opts:
             table_opts.append(f'PRIMARY KEY({opts["PRIMARY_KEY"]})')
 
-        if 'DISTRIBUTED_BY' in opts:
+        if "PARTITION_BY" in opts:
+            table_opts.append(f"PARTITION BY {opts['PARTITION_BY']}")
+
+        if "DISTRIBUTED_BY" in opts:
             table_opts.append(f'DISTRIBUTED BY HASH({opts["DISTRIBUTED_BY"]})')
 
-        if 'PARTITION_BY' in opts:
-            table_opts.append(f'PARTITION BY {opts["PARTITION_BY"]}')
-
-        if 'ORDER_BY' in opts:
-            table_opts.append(f'ORDER BY {opts["ORDER_BY"]}')
+        if "ORDER_BY" in opts:
+            table_opts.append(f"ORDER BY ({opts['ORDER_BY']})")
 
         if "COMMENT" in opts:
             comment = self.sql_compiler.render_literal_value(


### PR DESCRIPTION
Allow users to create starrocks tables w/ options like `PARTITION_BY` and `ORDER_BY`
```python
class MyTable(Base):
  __tablename__ = "my_table"
  ... 
  __table_args__ = {
        "starrocks_partition_by": "DATE_TRUNC('day', updated_at)",
        "starrocks_distributed_by": "merchant_id",
        "starrocks_order_by": "updated_at",
    }
```